### PR TITLE
SLNIM-1: Return compressionState: notCompressed

### DIFF
--- a/lib/src/network_image_mock.dart
+++ b/lib/src/network_image_mock.dart
@@ -31,6 +31,8 @@ MockHttpClient createMockImageHttpClient() {
   when(request.headers).thenReturn(headers);
   when(request.close())
       .thenAnswer((_) => Future<HttpClientResponse>.value(response));
+  when(response.compressionState)
+      .thenReturn(HttpClientResponseCompressionState.notCompressed);
   when(response.contentLength).thenReturn(image.length);
   when(response.statusCode).thenReturn(HttpStatus.ok);
   when(response.listen(any)).thenAnswer((Invocation invocation) {


### PR DESCRIPTION
This is required to avoid `ReachabilityError` being thrown on Flutter Dev channel.

<details>

<summary>Stack trace</summary>

```
2020-10-14T17:56:57.1718709Z ══╡ EXCEPTION CAUGHT BY SVG ╞═══════════════════════════════════════════════════════════════════════
2020-10-14T17:56:57.1719984Z The following ReachabilityError was thrown resolving a single-frame picture stream:
2020-10-14T17:56:57.1721070Z `null` encountered as case in a switch expression with a non-nullable enum type.
2020-10-14T17:56:57.1721626Z 
2020-10-14T17:56:57.1722112Z When the exception was thrown, this was the stack:
2020-10-14T17:56:57.1723009Z #0      consolidateHttpClientResponseBytes (package:flutter/src/foundation/consolidate_response.dart:59:3)
2020-10-14T17:56:57.1723939Z #1      httpGet (package:flutter_svg/src/utilities/_http_io.dart:22:10)
2020-10-14T17:56:57.1724914Z <asynchronous suspension>
2020-10-14T17:56:57.1726931Z #2      NetworkPicture._loadAsync (package:flutter_svg/src/picture_provider.dart:519:35)
2020-10-14T17:56:57.1728214Z #3      NetworkPicture.load (package:flutter_svg/src/picture_provider.dart:509:43)
2020-10-14T17:56:57.1729696Z #4      PictureProvider.resolve.<anonymous closure>.<anonymous closure> (package:flutter_svg/src/picture_provider.dart:331:17)
2020-10-14T17:56:57.1730661Z #5      PictureCache.putIfAbsent (package:flutter_svg/src/picture_cache.dart:67:22)
2020-10-14T17:56:57.1731587Z #6      PictureProvider.resolve.<anonymous closure> (package:flutter_svg/src/picture_provider.dart:329:16)
2020-10-14T17:56:57.1732539Z #7      SynchronousFuture.then (package:flutter/src/foundation/synchronous_future.dart:41:35)
2020-10-14T17:56:57.1733434Z #8      PictureProvider.resolve (package:flutter_svg/src/picture_provider.dart:326:24)
2020-10-14T17:56:57.1734414Z #9      _SvgPictureState._resolveImage (package:flutter_svg/svg.dart:664:10)
2020-10-14T17:56:57.1740212Z #10     _SvgPictureState.didChangeDependencies (package:flutter_svg/svg.dart:638:5)
2020-10-14T17:56:57.1741105Z #11     StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4833:11)
2020-10-14T17:56:57.1741766Z #12     ComponentElement.mount (package:flutter/src/widgets/framework.dart:4649:5)
2020-10-14T17:56:57.1742274Z ...     Normal element mounting (69 frames)
2020-10-14T17:56:57.1742768Z #81     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3615:14)
2020-10-14T17:56:57.1743599Z #82     MultiChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:6282:32)
2020-10-14T17:56:57.1744279Z ...     Normal element mounting (224 frames)
2020-10-14T17:56:57.1744935Z #306    Element.inflateWidget (package:flutter/src/widgets/framework.dart:3615:14)
2020-10-14T17:56:57.1745986Z #307    MultiChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:6282:32)
2020-10-14T17:56:57.1746701Z ...     Normal element mounting (309 frames)
2020-10-14T17:56:57.1747205Z #616    Element.inflateWidget (package:flutter/src/widgets/framework.dart:3615:14)
2020-10-14T17:56:57.1749017Z #617    Element.updateChild (package:flutter/src/widgets/framework.dart:3377:20)
2020-10-14T17:56:57.1749756Z #618    RenderObjectToWidgetElement._rebuild (package:flutter/src/widgets/binding.dart:1215:16)
2020-10-14T17:56:57.1750788Z #619    RenderObjectToWidgetElement.update (package:flutter/src/widgets/binding.dart:1193:5)
2020-10-14T17:56:57.1752064Z #620    RenderObjectToWidgetElement.performRebuild (package:flutter/src/widgets/binding.dart:1207:7)
2020-10-14T17:56:57.1752953Z #621    Element.rebuild (package:flutter/src/widgets/framework.dart:4369:5)
2020-10-14T17:56:57.1753556Z #622    BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2777:33)
2020-10-14T17:56:57.1755057Z #623    AutomatedTestWidgetsFlutterBinding.drawFrame (package:flutter_test/src/binding.dart:1104:19)
2020-10-14T17:56:57.1756575Z #624    RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:309:5)
2020-10-14T17:56:57.1757589Z #625    SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1117:15)
2020-10-14T17:56:57.1759244Z #626    SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1055:9)
2020-10-14T17:56:57.1760365Z #627    AutomatedTestWidgetsFlutterBinding.pump.<anonymous closure> (package:flutter_test/src/binding.dart:974:9)
2020-10-14T17:56:57.1761314Z #630    TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:72:41)
2020-10-14T17:56:57.1762180Z #631    AutomatedTestWidgetsFlutterBinding.pump (package:flutter_test/src/binding.dart:961:27)
2020-10-14T17:56:57.1763150Z #632    WidgetTester.pumpWidget.<anonymous closure> (package:flutter_test/src/widget_tester.dart:522:22)
2020-10-14T17:56:57.1763873Z #635    TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:72:41)
2020-10-14T17:56:57.1764532Z #636    WidgetTester.pumpWidget (package:flutter_test/src/widget_tester.dart:519:27)
2020-10-14T17:56:57.1765331Z #637    explain (file:///home/runner/work/flutter_widget_from_html/flutter_widget_from_html/packages/core/test/_.dart:58:16)
2020-10-14T17:56:57.1766018Z #638    explain (file:///home/runner/work/flutter_widget_from_html/flutter_widget_from_html/packages/enhanced/test/_.dart:59:5)
2020-10-14T17:56:57.1766900Z #639    main.<anonymous closure>.<anonymous closure>.<anonymous closure> (file:///home/runner/work/flutter_widget_from_html/flutter_widget_from_html/packages/enhanced/test/tag_img_test.dart:115:58)
2020-10-14T17:56:57.1767724Z #644    HttpOverrides.runZoned (dart:_http/overrides.dart:55:26)
2020-10-14T17:56:57.1768498Z #645    mockNetworkImagesFor (package:network_image_mock/src/network_image_mock.dart:8:24)
2020-10-14T17:56:57.1769277Z #646    main.<anonymous closure>.<anonymous closure> (file:///home/runner/work/flutter_widget_from_html/flutter_widget_from_html/packages/enhanced/test/tag_img_test.dart:115:31)
2020-10-14T17:56:57.1770425Z #647    main.<anonymous closure>.<anonymous closure> (file:///home/runner/work/flutter_widget_from_html/flutter_widget_from_html/packages/enhanced/test/tag_img_test.dart:112:44)
2020-10-14T17:56:57.1771251Z #648    testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:144:29)
2020-10-14T17:56:57.1773044Z #659    FakeAsync.flushMicrotasks (package:fake_async/fake_async.dart:193:32)
2020-10-14T17:56:57.1774042Z #660    AutomatedTestWidgetsFlutterBinding.runTest.<anonymous closure> (package:flutter_test/src/binding.dart:1208:17)
2020-10-14T17:56:57.1775358Z #661    AutomatedTestWidgetsFlutterBinding.runTest.<anonymous closure> (package:flutter_test/src/binding.dart:1195:35)
2020-10-14T17:56:57.1776620Z (elided 33 frames from dart:async and package:stack_trace)
2020-10-14T17:56:57.1776885Z 
2020-10-14T17:56:57.1777371Z Picture provider: NetworkPicture("http://domain.com/image.svg", headers: null, colorFilter: null)
2020-10-14T17:56:57.1779846Z Picture key: NetworkPicture("http://domain.com/image.svg", headers: null, colorFilter: null)
```

</details>